### PR TITLE
Fix serializer bindings

### DIFF
--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonArray.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonArray.kt
@@ -15,12 +15,16 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonArraySerializer
+
 /**
  * A type-safe representation of the BSON array type.
  *
  * @constructor constructs the bson array with an initial list of values, defaults to no items
  * @param initial the initial list of [BsonValue]s in the array
  */
+@Serializable(with= BsonArraySerializer::class)
 public class BsonArray(initial: List<BsonValue> = emptyList()) : BsonValue(), MutableList<BsonValue> {
     private val _values: MutableList<BsonValue>
     init {

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonBinary.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonBinary.kt
@@ -15,6 +15,9 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonBinarySerializer
+
 /**
  * A representation of the BSON Binary type.
  *
@@ -25,6 +28,7 @@ package org.mongodb.kbson
  * @property type the [BsonBinarySubType] byte value
  * @property data the [ByteArray]
  */
+@Serializable(with = BsonBinarySerializer::class)
 public class BsonBinary(public val type: Byte, public val data: ByteArray) : BsonValue() {
 
     /**

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonBoolean.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonBoolean.kt
@@ -15,6 +15,8 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonBooleanSerializer
 import kotlin.jvm.JvmStatic
 
 /**
@@ -23,6 +25,7 @@ import kotlin.jvm.JvmStatic
  * @constructor constructs a new instance with the given value
  * @property value the boolean value
  */
+@Serializable(with = BsonBooleanSerializer::class)
 public class BsonBoolean(public val value: Boolean) : BsonValue(), Comparable<BsonBoolean> {
 
     override val bsonType: BsonType

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonDBPointer.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonDBPointer.kt
@@ -15,6 +15,9 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonDBPointerSerializer
+
 /**
  * A representation of the BSON DBPointer type.
  *
@@ -24,6 +27,7 @@ package org.mongodb.kbson
  * @property namespace the namespace
  * @property id the id
  */
+@Serializable(with = BsonDBPointerSerializer::class)
 public class BsonDBPointer(public val namespace: String, public val id: BsonObjectId) : BsonValue() {
 
     override val bsonType: BsonType

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonDateTime.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonDateTime.kt
@@ -15,7 +15,9 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
 import org.mongodb.kbson.internal.CurrentTime.getCurrentTimeInMillis
+import org.mongodb.kbson.serialization.BsonDateTimeSerializer
 
 /**
  * A representation of the BSON DateTime type.
@@ -23,6 +25,7 @@ import org.mongodb.kbson.internal.CurrentTime.getCurrentTimeInMillis
  * @constructor constructs a new instance with the given value
  * @property value the time in milliseconds since epoch
  */
+@Serializable(with = BsonDateTimeSerializer::class)
 public class BsonDateTime(public val value: Long) : BsonValue(), Comparable<BsonDateTime> {
 
     /** Construct a new instance with 'now' as the current date time */

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonDecimal128.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonDecimal128.kt
@@ -15,7 +15,9 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
 import org.mongodb.kbson.internal.Decimal128
+import org.mongodb.kbson.serialization.BsonDecimal128Serializer
 
 /**
  * A binary integer decimal representation of a 128-bit decimal value, supporting 34 decimal digits of significand and
@@ -32,6 +34,7 @@ import org.mongodb.kbson.internal.Decimal128
  *
  * @property value the Decimal128 value
  */
+@Serializable(with = BsonDecimal128Serializer::class)
 public class BsonDecimal128 private constructor(internal val value: Decimal128) : BsonValue() {
     override val bsonType: BsonType
         get() = BsonType.DECIMAL128

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonDocument.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonDocument.kt
@@ -15,12 +15,14 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
 import org.mongodb.kbson.internal.io.BsonBinaryReader
 import org.mongodb.kbson.internal.io.BsonBinaryWriter
 import org.mongodb.kbson.internal.io.BsonDocumentReader
 import org.mongodb.kbson.internal.io.BsonDocumentWriter
 import org.mongodb.kbson.internal.use
 import org.mongodb.kbson.serialization.Bson
+import org.mongodb.kbson.serialization.BsonDocumentSerializer
 
 /**
  * A type-safe container for a BSON document.
@@ -29,6 +31,7 @@ import org.mongodb.kbson.serialization.Bson
  * @param initial the initial values
  */
 @Suppress("TooManyFunctions")
+@Serializable(with = BsonDocumentSerializer::class)
 public class BsonDocument(initial: Map<String, BsonValue> = LinkedHashMap()) :
     BsonValue(), MutableMap<String, BsonValue> {
     private val _values: LinkedHashMap<String, BsonValue>

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonDouble.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonDouble.kt
@@ -15,12 +15,16 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonDoubleSerializer
+
 /**
  * A representation of the BSON Double type.
  *
  * @constructor constructs a new instance with the given value
  * @property value the [Double] value
  */
+@Serializable(with = BsonDoubleSerializer::class)
 public class BsonDouble(public val value: Double) : BsonNumber(value), Comparable<BsonDouble> {
 
     override val bsonType: BsonType

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonInt32.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonInt32.kt
@@ -15,12 +15,16 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonInt32Serializer
+
 /**
  * A representation of the BSON Int32 type.
  *
  * @constructor constructs a new instance with the given value
  * @property value the value
  */
+@Serializable(with = BsonInt32Serializer::class)
 public class BsonInt32(public val value: Int) : BsonNumber(value), Comparable<BsonInt32> {
 
     override val bsonType: BsonType

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonInt64.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonInt64.kt
@@ -15,12 +15,16 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonInt64Serializer
+
 /**
  * A representation of the BSON Int64 type.
  *
  * @constructor constructs a new instance with the given value
  * @property value the value
  */
+@Serializable(with = BsonInt64Serializer::class)
 public class BsonInt64(public val value: Long) : BsonNumber(value), Comparable<BsonInt64> {
 
     override val bsonType: BsonType

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonJavaScript.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonJavaScript.kt
@@ -15,12 +15,16 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonJavaScriptSerializer
+
 /**
  * A representation of the BSON JavaScript type.
  *
  * @constructor constructs a new instance with the given code
  * @property code the javascript code as a string
  */
+@Serializable(with = BsonJavaScriptSerializer::class)
 public class BsonJavaScript(public val code: String) : BsonValue() {
     override val bsonType: BsonType
         get() = BsonType.JAVASCRIPT

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonJavaScriptWithScope.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonJavaScriptWithScope.kt
@@ -15,6 +15,9 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonJavaScriptWithScopeSerializer
+
 /**
  * A representation of the BSON JavaScript with scope type.
  *
@@ -22,6 +25,7 @@ package org.mongodb.kbson
  * @property code the javascript code as a string
  * @property scope the javascript scope
  */
+@Serializable(with = BsonJavaScriptWithScopeSerializer::class)
 public class BsonJavaScriptWithScope(public val code: String, public val scope: BsonDocument) : BsonValue() {
     override val bsonType: BsonType
         get() = BsonType.JAVASCRIPT_WITH_SCOPE

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonMaxKey.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonMaxKey.kt
@@ -15,7 +15,11 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonMaxKeySerializer
+
 /** A representation of the BSON the maximum key value regardless of the key's type */
+@Serializable(with = BsonMaxKeySerializer::class)
 public object BsonMaxKey : BsonValue() {
     override val bsonType: BsonType
         get() = BsonType.MAX_KEY

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonMinKey.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonMinKey.kt
@@ -15,7 +15,11 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonMinKeySerializer
+
 /** A representation of the BSON the minimum key value regardless of the key's type */
+@Serializable(with = BsonMinKeySerializer::class)
 public object BsonMinKey : BsonValue() {
     override val bsonType: BsonType
         get() = BsonType.MIN_KEY

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonNull.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonNull.kt
@@ -15,9 +15,12 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonNullSerializer
 import kotlin.jvm.JvmStatic
 
 /** A representation of the BSON Null type. */
+@Serializable(with = BsonNullSerializer::class)
 public object BsonNull : BsonValue() {
     override val bsonType: BsonType
         get() = BsonType.NULL

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonObjectId.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonObjectId.kt
@@ -15,9 +15,11 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
 import org.mongodb.kbson.internal.AtomicInt
 import org.mongodb.kbson.internal.CurrentTime.getCurrentTimeInSeconds
 import org.mongodb.kbson.internal.HexUtils
+import org.mongodb.kbson.serialization.BsonObjectIdSerializer
 
 /**
  * A representation of the BSON ObjectId type
@@ -40,6 +42,7 @@ import org.mongodb.kbson.internal.HexUtils
  * @property counter a counter
  */
 @Suppress("MagicNumber")
+@Serializable(with = BsonObjectIdSerializer::class)
 public class BsonObjectId(
     public val timestamp: Int,
     private val randomValue1: Int,

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonRegularExpression.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonRegularExpression.kt
@@ -15,6 +15,9 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonRegularExpressionSerializer
+
 /**
  * A representation of the BSON regular expression type
  *
@@ -22,6 +25,7 @@ package org.mongodb.kbson
  * @property pattern the regular expression pattern
  * @param options the regular expression options
  */
+@Serializable(with = BsonRegularExpressionSerializer::class)
 public class BsonRegularExpression(public val pattern: String, options: String) : BsonValue() {
 
     /** The sorted options for the regular expression */

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonString.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonString.kt
@@ -15,11 +15,15 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonStringSerializer
+
 /**
  * A representation of the BSON String type.
  *
  * @property value the string value
  */
+@Serializable(with = BsonStringSerializer::class)
 public class BsonString(public val value: String) : BsonValue(), Comparable<BsonString> {
     override val bsonType: BsonType
         get() = BsonType.STRING

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonSymbol.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonSymbol.kt
@@ -15,6 +15,9 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonSymbolSerializer
+
 /**
  * A representation of the BSON Symbol type.
  *
@@ -22,6 +25,7 @@ package org.mongodb.kbson
  *
  * @property value the symbol value
  */
+@Serializable(with = BsonSymbolSerializer::class)
 public class BsonSymbol(public val value: String) : BsonValue() {
 
     /** Gets the symbol value */

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonTimestamp.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonTimestamp.kt
@@ -15,6 +15,9 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonTimestampSerializer
+
 /**
  * A representation the BSON timestamp type.
  *
@@ -27,6 +30,7 @@ package org.mongodb.kbson
  * @property value the timestamp
  */
 @Suppress("MagicNumber")
+@Serializable(with = BsonTimestampSerializer::class)
 public class BsonTimestamp(public val value: Long = 0) : BsonValue(), Comparable<BsonTimestamp> {
 
     /**

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonUndefined.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonUndefined.kt
@@ -15,6 +15,8 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
+import org.mongodb.kbson.serialization.BsonUndefinedSerializer
 import kotlin.jvm.JvmStatic
 
 /**
@@ -22,6 +24,7 @@ import kotlin.jvm.JvmStatic
  *
  * Note: It's deprecated in BSON Specification and present here only for compatibility reasons.
  */
+@Serializable(with = BsonUndefinedSerializer::class)
 public object BsonUndefined : BsonValue() {
 
     override val bsonType: BsonType

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonValue.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonValue.kt
@@ -15,10 +15,13 @@
  */
 package org.mongodb.kbson
 
+import kotlinx.serialization.Serializable
 import org.mongodb.kbson.serialization.Bson
+import org.mongodb.kbson.serialization.BsonValueSerializer
 
 /** Base class for any BSON type. */
 @Suppress("TooManyFunctions")
+@Serializable(with = BsonValueSerializer::class)
 public sealed class BsonValue {
 
     /**
@@ -180,7 +183,8 @@ public sealed class BsonValue {
     public fun asNumber(): BsonNumber {
         if (bsonType !== BsonType.INT32 && bsonType !== BsonType.INT64 && bsonType !== BsonType.DOUBLE) {
             throw BsonInvalidOperationException(
-                "Value expected to be of a numerical BSON type is of unexpected type $bsonType")
+                "Value expected to be of a numerical BSON type is of unexpected type $bsonType"
+            )
         }
         return this as BsonNumber
     }
@@ -395,7 +399,8 @@ public sealed class BsonValue {
     private fun throwIfInvalidType(expectedType: BsonType) {
         if (bsonType !== expectedType) {
             throw BsonInvalidOperationException(
-                "Value expected to be of type $expectedType is of unexpected type ${bsonType}")
+                "Value expected to be of type $expectedType is of unexpected type ${bsonType}"
+            )
         }
     }
 }

--- a/src/commonMain/kotlin/org/mongodb/kbson/internal/Decimal128.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/internal/Decimal128.kt
@@ -15,7 +15,6 @@
  */
 package org.mongodb.kbson.internal
 
-import kotlin.math.abs
 import org.mongodb.kbson.internal.Decimal128.Flags.FirstFormExponentBits
 import org.mongodb.kbson.internal.Decimal128.Flags.SecondFormExponentBits
 import org.mongodb.kbson.internal.Decimal128.Flags.isFirstForm
@@ -24,6 +23,7 @@ import org.mongodb.kbson.internal.Decimal128.Flags.isNegative
 import org.mongodb.kbson.internal.Decimal128.Flags.isNegativeInfinity
 import org.mongodb.kbson.internal.Decimal128.Flags.isPositiveInfinity
 import org.mongodb.kbson.internal.Decimal128.Flags.isSecondForm
+import kotlin.math.abs
 
 /**
  * A binary integer decimal representation of a 128-bit decimal value, supporting 34 decimal digits of significand and

--- a/src/commonMain/kotlin/org/mongodb/kbson/internal/Preconditions.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/internal/Preconditions.kt
@@ -15,10 +15,10 @@
  */
 package org.mongodb.kbson.internal
 
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
 import org.mongodb.kbson.BsonInvalidOperationException
 import org.mongodb.kbson.BsonSerializationException
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 @OptIn(ExperimentalContracts::class)
 internal inline fun validateSerialization(value: Boolean, lazyMessage: () -> Any) {

--- a/src/jvmTest/kotlin/org/mongodb/kbson/BsonValueApiTest.kt
+++ b/src/jvmTest/kotlin/org/mongodb/kbson/BsonValueApiTest.kt
@@ -21,9 +21,9 @@ import java.util.UUID
 import kotlin.jvm.internal.DefaultConstructorMarker
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
+import org.mongodb.kbson.serialization.Bson
 
 class BsonValueApiTest {
-
     @Test
     fun bsonArrayTest() {
         val bsonClass = org.bson.BsonArray::class.java
@@ -222,7 +222,7 @@ class BsonValueApiTest {
         // No constructor as it's a singleton object
 
         val bsonMethods = getMethodNames(bsonClass)
-        val kBsonMethods = getMethodNames(kBsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass, listOf("serializer"))
         assertEquals(bsonMethods, kBsonMethods)
     }
 
@@ -234,7 +234,7 @@ class BsonValueApiTest {
         // No constructor as it's a singleton object
 
         val bsonMethods = getMethodNames(bsonClass)
-        val kBsonMethods = getMethodNames(kBsonClass)
+        val kBsonMethods = getMethodNames(kBsonClass, listOf("serializer"))
         assertEquals(bsonMethods, kBsonMethods)
     }
 
@@ -246,7 +246,7 @@ class BsonValueApiTest {
         // No constructor as it's a singleton object
 
         val bsonMethods = getMethodNames(bsonClass)
-        val kBsonMethods = getMethodNames(kBsonClass, listOf("getVALUE", "getVALUE\$annotations"))
+        val kBsonMethods = getMethodNames(kBsonClass, listOf("getVALUE", "getVALUE\$annotations", "serializer"))
         assertEquals(bsonMethods, kBsonMethods)
     }
 
@@ -331,7 +331,7 @@ class BsonValueApiTest {
         // No constructor as it's a singleton object
 
         val bsonMethods = getMethodNames(bsonClass)
-        val kBsonMethods = getMethodNames(kBsonClass, listOf("getUNDEFINED", "getUNDEFINED\$annotations"))
+        val kBsonMethods = getMethodNames(kBsonClass, listOf("getUNDEFINED", "getUNDEFINED\$annotations", "serializer"))
         assertEquals(bsonMethods, kBsonMethods)
     }
 


### PR DESCRIPTION
This PR attempts to resolve the issue that the serializer for the different `Bson` types is not being picked up in consumer apps. 

They are not picked up automatically because the models lack the `serializer` method in their companion object. The @Serializable annotation has been added to the different models to get it automatically populated.

Removes the `BsonSerializersModule` as it is no longer needed.