### PR TITLE
Remove experimental APIs

### DIFF
--- a/src/commonMain/kotlin/org/mongodb/kbson/serialization/Serializers.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/serialization/Serializers.kt
@@ -96,7 +96,10 @@ public object Bson {
 
 internal object BsonValueSerializer : KSerializer<BsonValue> {
 
-    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("BsonDocument") {}
+    @Serializable
+    private class BsonValueJson
+
+    override val descriptor: SerialDescriptor = BsonValueJson.serializer().descriptor
 
     @Suppress("ComplexMethod")
     override fun serialize(encoder: Encoder, value: BsonValue) {


### PR DESCRIPTION
Removes any use of `kserializer` experimental APIs:

- `@Serializer(forClass =` can be removed because the serializer are defined in the `Bson` type.
- It is unnecessary to instantiate `SerialDescriptor` as we use a [serializer via surrogates.](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#composite-serializer-via-surrogate)