### PR TITLE
Add support for public Decimal128 high and low values

### DIFF
--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonDecimal128.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonDecimal128.kt
@@ -40,6 +40,24 @@ public class BsonDecimal128 private constructor(internal val value: Decimal128) 
         get() = BsonType.DECIMAL128
 
     /**
+     * Gets the low-order 64 bits of the IEEE 754-2008 128-bit decimal floating point encoding for this Decimal128,
+     * using the BID encoding scheme.
+     *
+     * @return the low-order 64 bits of this Decimal128
+     */
+    public val high: ULong
+        get() = value.high
+
+    /**
+     * Gets the high-order 64 bits of the IEEE 754-2008 128-bit decimal floating point encoding for this Decimal128,
+     * using the BID encoding scheme.
+     *
+     * @return the high-order 64 bits of this Decimal128
+     */
+    public val low: ULong
+        get() = value.low
+
+    /**
      * Returns true if this BsonDecimal128 is negative.
      *
      * @return true if this BsonDecimal128 is negative

--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonDecimal128.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonDecimal128.kt
@@ -40,19 +40,19 @@ public class BsonDecimal128 private constructor(internal val value: Decimal128) 
         get() = BsonType.DECIMAL128
 
     /**
-     * Gets the low-order 64 bits of the IEEE 754-2008 128-bit decimal floating point encoding for this Decimal128,
+     * Gets the high-order 64 bits of the IEEE 754-2008 128-bit decimal floating point encoding for this Decimal128,
      * using the BID encoding scheme.
      *
-     * @return the low-order 64 bits of this Decimal128
+     * @return the high-order 64 bits of this Decimal128
      */
     public val high: ULong
         get() = value.high
 
     /**
-     * Gets the high-order 64 bits of the IEEE 754-2008 128-bit decimal floating point encoding for this Decimal128,
+     * Gets the low-order 64 bits of the IEEE 754-2008 128-bit decimal floating point encoding for this Decimal128,
      * using the BID encoding scheme.
      *
-     * @return the high-order 64 bits of this Decimal128
+     * @return the low-order 64 bits of this Decimal128
      */
     public val low: ULong
         get() = value.low

--- a/src/commonTest/kotlin/org/mongodb/kbson/BsonDecimal128Test.kt
+++ b/src/commonTest/kotlin/org/mongodb/kbson/BsonDecimal128Test.kt
@@ -45,6 +45,24 @@ class BsonDecimal128Test {
     }
 
     @Test
+    fun highLowValues() {
+        assertEquals(1uL, bsonValue.high)
+        assertEquals(2uL, bsonValue.low)
+        assertEquals(0x7c00000000000000uL, BsonDecimal128.NaN.high)
+        assertEquals(0uL, BsonDecimal128.NaN.low)
+        assertEquals(0x7c00000000000000uL or 1uL.shl(63), BsonDecimal128.NEGATIVE_NaN.high)
+        assertEquals(0uL, BsonDecimal128.NEGATIVE_NaN.low)
+        assertEquals(0x7800000000000000uL, BsonDecimal128.POSITIVE_INFINITY.high)
+        assertEquals(0uL, BsonDecimal128.POSITIVE_INFINITY.low)
+        assertEquals(0x7800000000000000uL or 1uL.shl(63), BsonDecimal128.NEGATIVE_INFINITY.high)
+        assertEquals(0uL, BsonDecimal128.NEGATIVE_INFINITY.low)
+        assertEquals(0x3040000000000000uL, BsonDecimal128.POSITIVE_ZERO.high)
+        assertEquals(0uL, BsonDecimal128.POSITIVE_ZERO.low)
+        assertEquals(0xb040000000000000uL, BsonDecimal128.NEGATIVE_ZERO.high)
+        assertEquals(0uL, BsonDecimal128.NEGATIVE_ZERO.low)
+    }
+
+    @Test
     fun shouldHaveCompanionHelpersForSpecialTypes() {
         assertEquals(BsonDecimal128.NaN, BsonDecimal128("NaN"))
         assertEquals(BsonDecimal128.NEGATIVE_NaN, BsonDecimal128("-NaN"))

--- a/src/jvmTest/kotlin/org/mongodb/kbson/BsonValueApiTest.kt
+++ b/src/jvmTest/kotlin/org/mongodb/kbson/BsonValueApiTest.kt
@@ -116,8 +116,8 @@ class BsonValueApiTest {
                     "isInfinite",
                     "isFinite",
                     "isNegative",
-                    "getHigh",
-                    "getLow",
+                    "getHigh-s-VKNKU",
+                    "getLow-s-VKNKU",
                     "getValue\$kbson",
                     "getValue\$kbson_debug",
                     "getValue\$kbson_release"))


### PR DESCRIPTION
Closes #10 

In BSON for Java, the `Decimal128.getHigh()` and `Decimal128.getLow()` values are public. They where accidentally hidden in KBSON.

This PR makes them public.