### PR TITLE
Rename BsonBoolean.TRUE/FALSE to TRUE_VALUE/FALSE_VALUE

### DIFF
--- a/src/commonMain/kotlin/org/mongodb/kbson/BsonBoolean.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/BsonBoolean.kt
@@ -56,20 +56,20 @@ public class BsonBoolean(public val value: Boolean) : BsonValue(), Comparable<Bs
 
     public companion object {
         /** The true value. */
-        @JvmStatic public val TRUE: BsonBoolean = BsonBoolean(true)
+        @JvmStatic public val TRUE_VALUE: BsonBoolean = BsonBoolean(true)
 
         /** The false value. */
-        @JvmStatic public val FALSE: BsonBoolean = BsonBoolean(false)
+        @JvmStatic public val FALSE_VALUE: BsonBoolean = BsonBoolean(false)
 
         /**
          * Returns a `BsonBoolean` instance representing the specified `boolean` value.
          *
          * @param value a boolean value.
-         * @return @link if `value` is true, [BsonBoolean.FALSE] if `value` is false
+         * @return @link if `value` is true, [BsonBoolean.FALSE_VALUE] if `value` is false
          */
         @JvmStatic
         public fun valueOf(value: Boolean): BsonBoolean {
-            return if (value) TRUE else FALSE
+            return if (value) TRUE_VALUE else FALSE_VALUE
         }
     }
 }

--- a/src/commonTest/kotlin/org/mongodb/kbson/BsonArrayTest.kt
+++ b/src/commonTest/kotlin/org/mongodb/kbson/BsonArrayTest.kt
@@ -26,7 +26,7 @@ import kotlin.test.assertTrue
 
 class BsonArrayTest {
 
-    private val listOfBsonValues = listOf(BsonBoolean.TRUE, BsonBoolean.FALSE)
+    private val listOfBsonValues = listOf(BsonBoolean.TRUE_VALUE, BsonBoolean.FALSE_VALUE)
     private val bsonValue = BsonArray(listOfBsonValues)
 
     @Test
@@ -65,57 +65,57 @@ class BsonArrayTest {
         assertEquals(BsonArray(), BsonArray())
         assertEquals(bsonValue, bsonValue)
         assertNotEquals(BsonArray(), bsonValue)
-        assertNotEquals(bsonValue, BsonArray(listOf(BsonBoolean.TRUE, BsonBoolean.TRUE)))
+        assertNotEquals(bsonValue, BsonArray(listOf(BsonBoolean.TRUE_VALUE, BsonBoolean.TRUE_VALUE)))
     }
 
     @Test
     fun shouldSupportListMethods() {
-        assertTrue(bsonValue.contains(BsonBoolean.TRUE))
+        assertTrue(bsonValue.contains(BsonBoolean.TRUE_VALUE))
         assertFalse(bsonValue.contains(BsonUndefined.UNDEFINED))
 
-        assertTrue(bsonValue.containsAll(listOf(BsonBoolean.TRUE)))
-        assertFalse(bsonValue.containsAll(listOf(BsonBoolean.TRUE, BsonUndefined.UNDEFINED)))
+        assertTrue(bsonValue.containsAll(listOf(BsonBoolean.TRUE_VALUE)))
+        assertFalse(bsonValue.containsAll(listOf(BsonBoolean.TRUE_VALUE, BsonUndefined.UNDEFINED)))
 
         val iterator = bsonValue.iterator()
         assertTrue(iterator.hasNext())
-        assertEquals(BsonBoolean.TRUE, iterator.next())
+        assertEquals(BsonBoolean.TRUE_VALUE, iterator.next())
         assertTrue(iterator.hasNext())
-        assertEquals(BsonBoolean.FALSE, iterator.next())
+        assertEquals(BsonBoolean.FALSE_VALUE, iterator.next())
         assertFalse(iterator.hasNext())
 
         val listIterator = bsonValue.listIterator()
         assertFalse(listIterator.hasPrevious())
         assertTrue(listIterator.hasNext())
-        assertEquals(BsonBoolean.TRUE, listIterator.next())
-        assertEquals(BsonBoolean.TRUE, listIterator.previous())
-        assertEquals(BsonBoolean.TRUE, listIterator.next())
-        assertEquals(BsonBoolean.FALSE, listIterator.next())
+        assertEquals(BsonBoolean.TRUE_VALUE, listIterator.next())
+        assertEquals(BsonBoolean.TRUE_VALUE, listIterator.previous())
+        assertEquals(BsonBoolean.TRUE_VALUE, listIterator.next())
+        assertEquals(BsonBoolean.FALSE_VALUE, listIterator.next())
         assertTrue(listIterator.hasPrevious())
         assertFalse(listIterator.hasNext())
 
         val subListIterator = bsonValue.listIterator(1)
         assertTrue(subListIterator.hasPrevious())
         assertTrue(subListIterator.hasNext())
-        assertEquals(BsonBoolean.FALSE, subListIterator.next())
+        assertEquals(BsonBoolean.FALSE_VALUE, subListIterator.next())
         assertTrue(subListIterator.hasPrevious())
         assertFalse(subListIterator.hasNext())
 
-        assertEquals(mutableListOf<BsonValue>(BsonBoolean.FALSE), bsonValue.subList(1, 2))
+        assertEquals(mutableListOf<BsonValue>(BsonBoolean.FALSE_VALUE), bsonValue.subList(1, 2))
         assertEquals(
             2,
             org.mongodb.kbson
-                .BsonArray(listOf(BsonBoolean.TRUE, BsonBoolean.TRUE, BsonBoolean.TRUE))
-                .lastIndexOf(BsonBoolean.TRUE))
-        assertEquals(1, bsonValue.indexOf(BsonBoolean.FALSE))
+                .BsonArray(listOf(BsonBoolean.TRUE_VALUE, BsonBoolean.TRUE_VALUE, BsonBoolean.TRUE_VALUE))
+                .lastIndexOf(BsonBoolean.TRUE_VALUE))
+        assertEquals(1, bsonValue.indexOf(BsonBoolean.FALSE_VALUE))
     }
 
     @Test
     fun shouldSupportMutableListMethods() {
         val mutableList = BsonArray()
 
-        assertTrue(mutableList.add(BsonBoolean.TRUE))
+        assertTrue(mutableList.add(BsonBoolean.TRUE_VALUE))
         assertFalse(mutableList.isEmpty())
-        assertTrue(mutableList.remove(BsonBoolean.TRUE))
+        assertTrue(mutableList.remove(BsonBoolean.TRUE_VALUE))
         assertTrue(mutableList.isEmpty())
 
         assertTrue(mutableList.addAll(listOfBsonValues))
@@ -123,7 +123,7 @@ class BsonArrayTest {
         assertTrue(mutableList.removeAll(listOfBsonValues))
         assertTrue(mutableList.isEmpty())
 
-        mutableList.addAll(listOf(BsonNull, BsonBoolean.TRUE, BsonBoolean.FALSE, BsonUndefined))
+        mutableList.addAll(listOf(BsonNull, BsonBoolean.TRUE_VALUE, BsonBoolean.FALSE_VALUE, BsonUndefined))
         assertEquals(BsonNull, mutableList.removeAt(0))
         assertEquals(3, mutableList.size)
 
@@ -135,13 +135,13 @@ class BsonArrayTest {
         assertEquals(BsonNull, mutableList.set(0, BsonMinKey))
         assertEquals(BsonMinKey, mutableList.first())
 
-        val expected = listOf(BsonMinKey, BsonBoolean.TRUE, BsonBoolean.FALSE, BsonUndefined, BsonMaxKey)
+        val expected = listOf(BsonMinKey, BsonBoolean.TRUE_VALUE, BsonBoolean.FALSE_VALUE, BsonUndefined, BsonMaxKey)
         assertContentEquals(expected, mutableList.values)
 
         assertTrue(mutableList.retainAll(listOf(BsonMinKey, BsonMaxKey, BsonUndefined)))
         assertContentEquals(listOf(BsonMinKey, BsonUndefined, BsonMaxKey), mutableList.values)
 
-        assertTrue(mutableList.addAll(1, listOf(BsonBoolean.TRUE, BsonBoolean.FALSE)))
+        assertTrue(mutableList.addAll(1, listOf(BsonBoolean.TRUE_VALUE, BsonBoolean.FALSE_VALUE)))
         assertEquals(expected, mutableList.values)
 
         mutableList.clear()

--- a/src/commonTest/kotlin/org/mongodb/kbson/BsonBooleanTest.kt
+++ b/src/commonTest/kotlin/org/mongodb/kbson/BsonBooleanTest.kt
@@ -25,8 +25,8 @@ class BsonBooleanTest {
 
     @Test
     fun shouldHaveTheExpectedBsonType() {
-        assertTrue { BsonBoolean.TRUE.isBoolean() }
-        assertEquals(BsonType.BOOLEAN, BsonBoolean.TRUE.bsonType)
+        assertTrue { BsonBoolean.TRUE_VALUE.isBoolean() }
+        assertEquals(BsonType.BOOLEAN, BsonBoolean.TRUE_VALUE.bsonType)
     }
 
     @Test
@@ -37,17 +37,17 @@ class BsonBooleanTest {
 
     @Test
     fun shouldOverrideEquals() {
-        assertEquals(BsonBoolean.TRUE, BsonBoolean(true))
-        assertEquals(BsonBoolean.FALSE, BsonBoolean(false))
-        assertNotEquals(BsonBoolean.TRUE, BsonBoolean(false))
-        assertNotEquals(BsonBoolean.FALSE, BsonBoolean(true))
+        assertEquals(BsonBoolean.TRUE_VALUE, BsonBoolean(true))
+        assertEquals(BsonBoolean.FALSE_VALUE, BsonBoolean(false))
+        assertNotEquals(BsonBoolean.TRUE_VALUE, BsonBoolean(false))
+        assertNotEquals(BsonBoolean.FALSE_VALUE, BsonBoolean(true))
     }
 
     @Test
     fun shouldBeComparable() {
-        assertEquals(-1, BsonBoolean.FALSE.compareTo(BsonBoolean.TRUE))
-        assertEquals(0, BsonBoolean.TRUE.compareTo(BsonBoolean.TRUE))
-        assertEquals(0, BsonBoolean.FALSE.compareTo(BsonBoolean.FALSE))
-        assertEquals(1, BsonBoolean.TRUE.compareTo(BsonBoolean.FALSE))
+        assertEquals(-1, BsonBoolean.FALSE_VALUE.compareTo(BsonBoolean.TRUE_VALUE))
+        assertEquals(0, BsonBoolean.TRUE_VALUE.compareTo(BsonBoolean.TRUE_VALUE))
+        assertEquals(0, BsonBoolean.FALSE_VALUE.compareTo(BsonBoolean.FALSE_VALUE))
+        assertEquals(1, BsonBoolean.TRUE_VALUE.compareTo(BsonBoolean.FALSE_VALUE))
     }
 }

--- a/src/jvmTest/kotlin/org/mongodb/kbson/BsonValueApiTest.kt
+++ b/src/jvmTest/kotlin/org/mongodb/kbson/BsonValueApiTest.kt
@@ -64,7 +64,7 @@ class BsonValueApiTest {
         assertEquals(bsonConstructors, kBsonConstructors)
 
         val bsonMethods = getMethodNames(bsonClass)
-        val kBsonMethods = getMethodNames(kBsonClass, listOf("getTRUE", "getFALSE"))
+        val kBsonMethods = getMethodNames(kBsonClass, listOf("getTRUE_VALUE", "getFALSE_VALUE"))
 
         assertEquals(bsonMethods, kBsonMethods)
     }


### PR DESCRIPTION
Closes #9 

Rename the shortcut properties to avoid conflicts with reserved keywords in Swift. From Kotlin 1.8 it appears possible to just do this selectively in ObjC/Swift: https://kotlinlang.org/docs/whatsnew-eap.html#kotlin-native, but since that is in beta that isn't an option right now.

Renaming to `True/False` also fixes the issue, but that would make the capitalization incompatible with the rest of the code base (as well as the Kotlin style guide) so I opted for a slightly more verbose naming instead.