### PR TITLE
Parse all string literals into BsonStrings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,13 +18,13 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 group = "org.mongodb.kbson"
 
-version = "0.3.0"
+version = "0.4.0-SNAPSHOT"
 
 description = "KBSON a kotlin multiplatform implementation of the BSON library."
 
 plugins {
-    kotlin("multiplatform") version "1.6.10"
-    kotlin("plugin.serialization") version "1.6.10"
+    kotlin("multiplatform") version "1.7.20"
+    kotlin("plugin.serialization") version "1.7.20"
     id("com.android.library") version "7.3.0" apply false
     id("maven-publish")
     id("signing")
@@ -63,7 +63,7 @@ kotlin {
 
     sourceSets {
         val commonMain by getting {
-            dependencies { implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2") }
+            dependencies { implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1") }
         }
         val commonTest by getting {
             dependencies {

--- a/src/commonMain/kotlin/org/mongodb/kbson/serialization/Serializers.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/serialization/Serializers.kt
@@ -379,6 +379,9 @@ internal object BsonValueSerializer : KSerializer<BsonValue>, BsonSerializer {
                 return bsonArray
             }
             is JsonPrimitive -> {
+                if (jsonElement.isString) {
+                    return BsonString(jsonElement.content)
+                }
                 jsonElement.booleanOrNull?.let {
                     return BsonBoolean(it)
                 }
@@ -393,9 +396,6 @@ internal object BsonValueSerializer : KSerializer<BsonValue>, BsonSerializer {
                 }
                 jsonElement.doubleOrNull?.let {
                     return BsonDouble(it)
-                }
-                jsonElement.contentOrNull?.let {
-                    return BsonString(it)
                 }
                 return BsonNull
             }

--- a/src/commonMain/kotlin/org/mongodb/kbson/serialization/Serializers.kt
+++ b/src/commonMain/kotlin/org/mongodb/kbson/serialization/Serializers.kt
@@ -397,6 +397,9 @@ internal object BsonValueSerializer : KSerializer<BsonValue>, BsonSerializer {
                 jsonElement.doubleOrNull?.let {
                     return BsonDouble(it)
                 }
+                jsonElement.contentOrNull?.let {
+                    return BsonString(it)
+                }
                 return BsonNull
             }
             is JsonNull -> return BsonNull

--- a/src/commonTest/kotlin/org/mongodb/kbson/EjsonTest.kt
+++ b/src/commonTest/kotlin/org/mongodb/kbson/EjsonTest.kt
@@ -426,6 +426,20 @@ class EjsonTest {
         }
     }
 
+    @Test
+    fun nonStrict_primitiveValues() {
+        val bsonValues = EJson.decodeFromString<BsonValue>("[true, 1, 1.5, \"kbson\"]")
+        assertEquals(
+            BsonArray(listOf(BsonBoolean(true), BsonInt64(1), BsonDouble(1.5), BsonString("kbson"))), bsonValues)
+    }
+
+    @Test
+    fun nonStrict_strings() {
+        val bsonValues = EJson.decodeFromString<BsonValue>("[\"true\", \"1\", \"1.5\", \"kbson\"]")
+        assertEquals(
+            BsonArray(listOf(BsonString("true"), BsonString("1"), BsonString("1.5"), BsonString("kbson"))), bsonValues)
+    }
+
     // Assert that decoding `value` as an [AllTypes] fails.
     private inline fun <reified T> assertDecodingFailsWithInvalidType(value: T) {
         val encodedValue = EJson.encodeToString(value)


### PR DESCRIPTION
This PR parses of all non-strict EJSON string literals into `BsonString`-values. Prior to this, the string literals were parsed into most appropriate primitive type by trial on all primitive types supported by the underlying JsonElement-parser. 